### PR TITLE
feat: allow to pass order application context when initiating payment session

### DIFF
--- a/src/providers/paypal/paypal-core/paypal-core.ts
+++ b/src/providers/paypal/paypal-core/paypal-core.ts
@@ -27,6 +27,9 @@ export interface PaypalCreateOrderInput {
   shipping_info?: CartAddressDTO;
   items?: CartLineItemDTO[];
   email?: string;
+  locale?: string;
+  returnUrl?: string;
+  cancelUrl?: string;
 }
 
 export class PaypalService {
@@ -114,6 +117,9 @@ export class PaypalService {
     shipping_info,
     items,
     email,
+    locale,
+    returnUrl,
+    cancelUrl,
   }: PaypalCreateOrderInput): Promise<Order> {
     const ordersController = new OrdersController(this.client);
 
@@ -159,6 +165,9 @@ export class PaypalService {
           },
         ],
         applicationContext: {
+          returnUrl,
+          cancelUrl,
+          locale,
           ...(this.includeShippingData &&
             shippingData && {
               shippingPreference:

--- a/src/providers/paypal/service.ts
+++ b/src/providers/paypal/service.ts
@@ -368,6 +368,18 @@ export default class PaypalModuleService extends AbstractPaymentProvider<Alphabi
         items: data?.items,
         shipping_info: data?.shipping_info,
         email: data?.email,
+        locale:
+          data && "locale" in data && typeof data?.locale === "string"
+            ? data.locale
+            : undefined,
+        returnUrl:
+          data && "return_url" in data && typeof data?.return_url === "string"
+            ? data.return_url
+            : undefined,
+        cancelUrl:
+          data && "cancel_url" in data && typeof data?.cancel_url === "string"
+            ? data.cancel_url
+            : undefined,
       });
 
       return {


### PR DESCRIPTION
This PR allows to specify `return_url` and `cancel_url` when initiating the payment session.

Fixes https://github.com/alphabite-dev/medusa-paypal/issues/3