### PR TITLE
feat: handle checkout order approved event

### DIFF
--- a/src/providers/paypal/service.ts
+++ b/src/providers/paypal/service.ts
@@ -525,6 +525,16 @@ export default class PaypalModuleService extends AbstractPaymentProvider<Alphabi
       await this.client.verifyWebhook({ headers, body: data });
 
       switch (data.event_type) {
+        case "CHECKOUT.ORDER.APPROVED": {
+          const purchaseUnit = data.resource.purchase_units[0];
+          return {
+            action: "authorized",
+            data: {
+              session_id: purchaseUnit.custom_id,
+              amount: Number(purchaseUnit.amount.value),
+            },
+          };
+        }
         case "PAYMENT.CAPTURE.COMPLETED":
           return {
             action: "captured",
@@ -539,13 +549,24 @@ export default class PaypalModuleService extends AbstractPaymentProvider<Alphabi
           };
       }
     } catch (e) {
-      return {
-        action: "failed",
-        data: {
-          session_id: payload.data.resource.custom_id,
-          amount: Number(payload.data.resource.amount.value),
-        },
-      };
+      console.error("PayPal webhook verification failed:");
+      console.error(e);
+      const purchaseUnit =
+        ("purchase_units" in payload.data.resource &&
+          payload.data.resource?.purchase_units?.[0]) ||
+        ("custom_id" in payload.data.resource && payload.data.resource) ||
+        null;
+      return purchaseUnit
+        ? {
+            action: "failed",
+            data: {
+              session_id: purchaseUnit.custom_id,
+              amount: Number(purchaseUnit.amount.value),
+            },
+          }
+        : {
+            action: "failed",
+          };
     }
   }
 

--- a/src/providers/paypal/types.ts
+++ b/src/providers/paypal/types.ts
@@ -1,9 +1,17 @@
 import { ProviderWebhookPayload } from "@medusajs/framework/types";
 
-export type WebhookPayload = {
-  data: {
-    event_type: string;
-    resource: {
+export type PayPalWebhookPayloadDataShape<
+  E extends string,
+  R extends Record<string, any>
+> = {
+  event_type: E;
+  resource: R;
+};
+
+export type PayPalWebhookPayloadDataPaymentCaptureCompleted =
+  PayPalWebhookPayloadDataShape<
+    "PAYMENT.CAPTURE.COMPLETED",
+    {
       id: string;
       status: string;
       amount: {
@@ -11,8 +19,28 @@ export type WebhookPayload = {
         currency_code: string;
       };
       custom_id: string;
-    };
-  };
+    }
+  >;
+
+export type PayPalWebhookPayloadDataCheckoutOrderApproved =
+  PayPalWebhookPayloadDataShape<
+    "CHECKOUT.ORDER.APPROVED",
+    {
+      id: string;
+      purchase_units: Array<{
+        amount: {
+          value: string;
+          currency_code: string;
+        };
+        custom_id: string;
+      }>;
+    }
+  >;
+
+export type WebhookPayload = {
+  data:
+    | PayPalWebhookPayloadDataPaymentCaptureCompleted
+    | PayPalWebhookPayloadDataCheckoutOrderApproved;
   rawData: any;
   headers: Record<string, any>;
 } & ProviderWebhookPayload["payload"];


### PR DESCRIPTION
When trying to configure this plugin into my store, I found that after the checkout only the `CHECKOUT.ORDER.APPROVED` event was triggered through the webhook, but the `PAYMENT.CAPTURE.COMPLETED` was never called.

This PR handle the `CHECKOUT.ORDER.APPROVED` and authorizes the payment so Medusa invokes the `authorizePayment` method of the service. This does invoke the `captureOrder`, which eventually will trigger the other webhook to fully capture the payment.

Maybe I'm missing something but this is the only way I found to fully capture the payment, so if this is not correct or expected please let me know.

EDIT: I forced push because I started from my fork's main instead of the upstream's, so originally the PR contained other changes. Sorry about that.